### PR TITLE
added check for json object or array to handle cases where veracode w…

### DIFF
--- a/ea_veracodewrapper/src/main/java/com/cardinalhealth/veracodewrapper/Main.java
+++ b/ea_veracodewrapper/src/main/java/com/cardinalhealth/veracodewrapper/Main.java
@@ -153,9 +153,15 @@ public class Main {
         getFileList(uploadAPIWrapper, appID);
         try {
             String xml = uploadAPIWrapper.uploadFile(String.valueOf(appID), filePath);
-            // for debug
             JSONObject filelist = xmlToJson(xml).getJSONObject("filelist");
-            JSONArray uploadStatus = filelist.getJSONArray("file");
+            Object jsonCheck = filelist.get("file");
+            JSONArray uploadStatus = new JSONArray();
+            if (jsonCheck instanceof JSONArray){
+                uploadStatus = filelist.getJSONArray("file");
+            }
+            else {
+                uploadStatus.put(jsonCheck);
+            }
             for (int i = 0; i < uploadStatus.length(); i++) {
                 JSONObject json = uploadStatus.getJSONObject(i);
                 String fileStatus = json.getString("file_status");
@@ -216,18 +222,19 @@ public class Main {
         return null;
     }
 
-    private static JSONObject xmlToJson(String xml){
-        return XML.toJSONObject(xml);
-    }
+    private static JSONObject xmlToJson(String xml){ return XML.toJSONObject(xml); }
 
     private static boolean getFileList(UploadAPIWrapper uploadAPIWrapper, Integer appID) throws java.io.IOException {
         String xml = uploadAPIWrapper.getFileList(String.valueOf(appID));
         JSONObject filelist = xmlToJson(xml).getJSONObject("filelist");
-
-        JSONArray jFilelist;
-        jFilelist = filelist.getJSONArray("file");
-
-
+        Object jsonCheck = filelist.get("file");
+        JSONArray jFilelist = new JSONArray();
+        if (jsonCheck instanceof JSONArray) {
+            jFilelist = filelist.getJSONArray("file");
+        }
+        else {
+            jFilelist.put(jsonCheck);
+        }
         try {
             for (int i = 0; i < jFilelist.length(); i++) {
                 JSONObject json = jFilelist.getJSONObject(i);


### PR DESCRIPTION
…ould return

an object instead of an array. This was an edge case as it should only occur when a scan hasn't been performed for ~60 days. (the object returned in that case is a single object and not an array) The fix was to check for object type and if a JSONObject was found, add it to the array.

Change-Id: Ibcaddafacf171fe42767cc9fb24dbd8a3f9981b2